### PR TITLE
Sync with upstream to fix multiple Bad Request errors on coverage upload

### DIFF
--- a/SHA1SUM
+++ b/SHA1SUM
@@ -1,1 +1,1 @@
-352a2522e84ef9e43e77e37831280b3515cb895c  codecov
+00a587cad2ddfedbee35dc0b2e8ed7e35109c4f4  codecov

--- a/codecov
+++ b/codecov
@@ -1637,7 +1637,6 @@ else
             --data-binary @$upload_file.gz \
             -H 'Content-Type: application/x-gzip' \
             -H 'Content-Encoding: gzip' \
-             -H 'x-amz-acl: public-read' \
             "$s3target" || true)
 
 


### PR DESCRIPTION
The header `X-Amz-Acl` is no-longer needed and its usage may result in 400 Bad Request errors.

More info at https://github.com/codecov/codecov-bash/pull/302 and https://github.com/codecov/codecov-node/pull/179